### PR TITLE
Bug fix on path of field subdomain of VirtualMachine spec

### DIFF
--- a/modules/virt-creating-headless-services.adoc
+++ b/modules/virt-creating-headless-services.adoc
@@ -30,7 +30,7 @@ spec:
     port: 1234
     targetPort: 1234
 ----
-<1> The name of the service. This must match the `spec.subdomain` attribute in the `VirtualMachine` manifest file.
+<1> The name of the service. This must match the `spec.template.spec.subdomain` attribute in the `VirtualMachine` manifest file.
 <2> This service selector must match the `expose:me` label in the `VirtualMachine` manifest file.
 <3> Specifies a headless service.
 <4> The list of ports that are exposed by the service. You must define at least one port. This can be any arbitrary value as it does not affect the headless service.


### PR DESCRIPTION
The path of the subdomain for the VirtualMachine is wrong. It is located inside the template spec for the VirtualMachineInstance.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16 and 4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
